### PR TITLE
Update InputEventTests.cs to catch type failure

### DIFF
--- a/tests/SimConnect.NET.Tests.Net8/Tests/InputEventTests.cs
+++ b/tests/SimConnect.NET.Tests.Net8/Tests/InputEventTests.cs
@@ -172,6 +172,11 @@ namespace SimConnect.NET.Tests.Net8.Tests
                     {
                         await TestStringValueOperations(client, testEvent.Hash, currentValue, cancellationToken);
                     }
+                    else
+                    {
+                        Console.WriteLine($"      ❌ Input event test failed: Current value type unknown");
+                        return false;
+                    }
 
                     return true;
                 }


### PR DESCRIPTION
## Summary
Detect a failed test for TestInputEventGetSet


## Changes Made
Detect when the type is None

## Additional Information
I'm not sure certain events would actually pass, but it seems that grabbing the first fails silently when testing the C172 and SR22T.


## Author Information
**Discord Username:** bstudtma

---

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
