### PR TITLE
Fix SetInputEvent to accept hash as ulong

### DIFF
--- a/src/SimConnect.NET/InputEvents/InputEventManager.cs
+++ b/src/SimConnect.NET/InputEvents/InputEventManager.cs
@@ -209,7 +209,7 @@ namespace SimConnect.NET.InputEvents
                 try
                 {
                     Marshal.Copy(valueBytes, 0, valuePtr, valueBytes.Length);
-                    var result = SimConnectNative.SimConnect_SetInputEvent(this.simConnectHandle, (uint)hash, (uint)valueBytes.Length, valuePtr);
+                    var result = SimConnectNative.SimConnect_SetInputEvent(this.simConnectHandle, (ulong)hash, (uint)valueBytes.Length, valuePtr);
                     if (result != (int)SimConnectError.None)
                     {
                         throw new SimConnectException($"Failed to set input event: {(SimConnectError)result}", (SimConnectError)result);
@@ -245,7 +245,7 @@ namespace SimConnect.NET.InputEvents
                 try
                 {
                     Marshal.Copy(valueBytes, 0, valuePtr, valueBytes.Length);
-                    var result = SimConnectNative.SimConnect_SetInputEvent(this.simConnectHandle, (uint)hash, (uint)valueBytes.Length, valuePtr);
+                    var result = SimConnectNative.SimConnect_SetInputEvent(this.simConnectHandle, (ulong)hash, (uint)valueBytes.Length, valuePtr);
                     if (result != (int)SimConnectError.None)
                     {
                         throw new SimConnectException($"Failed to set input event: {(SimConnectError)result}", (SimConnectError)result);

--- a/src/SimConnect.NET/SimConnectNative.cs
+++ b/src/SimConnect.NET/SimConnectNative.cs
@@ -456,7 +456,7 @@ namespace SimConnect.NET
         [DllImport("SimConnect.dll")]
         public static extern int SimConnect_SetInputEvent(
             IntPtr hSimConnect,
-            uint hash,
+            ulong hash,
             uint cbUnitSize,
             IntPtr value);
 


### PR DESCRIPTION
Send event hash as ulong

## Summary
Fixed SetInputEvent to accept hash as ulong


## Changes Made
Fixed SetInputEvent to accept hash as ulong

## Additional Information
Tested with AS1000_CONTROLPAD_1 on the SR22T sending a value of 0.0


## Author Information
**Discord Username:** bstudtma
**VATSIM CID:**

---

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
