### PR TITLE
Fix GetInputEventAsync

### DIFF
--- a/src/SimConnect.NET/Enums/SimConnectInputEventType.cs
+++ b/src/SimConnect.NET/Enums/SimConnectInputEventType.cs
@@ -11,11 +11,6 @@ namespace SimConnect.NET
     public enum SimConnectInputEventType
     {
         /// <summary>
-        /// No data type specification required (C++ only).
-        /// </summary>
-        None,
-
-        /// <summary>
         /// Specifies a double value.
         /// </summary>
         DoubleValue,

--- a/src/SimConnect.NET/Structs/SimConnectRecvGetInputEvent.cs
+++ b/src/SimConnect.NET/Structs/SimConnectRecvGetInputEvent.cs
@@ -5,28 +5,7 @@
 namespace SimConnect.NET
 {
     /// <summary>
-    /// The SimConnectRecvGetInputEvent structure is used to return the value of a specific input event.
-    /// </summary>
-    public struct SimConnectRecvGetInputEvent
-    {
-        /// <summary>
-        /// Gets or sets the client-defined request ID.
-        /// </summary>
-        public uint RequestId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type of the input event. This is used to cast the Value to the correct type.
-        /// </summary>
-        public SimConnectInputEventType Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value of the requested input event, which should be cast to the correct format (float / string).
-        /// </summary>
-        public Object Value { get; set; }
-    }
-
-    /// <summary>
-    /// The SimConnectRecvGetInputEvent structure is used to return the value of a specific input event.
+    /// The SimConnectRecvGetInputEventHeader structure is used to return the header of a specific input event including the type but without the value.
     /// </summary>
     public struct SimConnectRecvGetInputEventHeader
     {

--- a/src/SimConnect.NET/Structs/SimConnectRecvGetInputEvent.cs
+++ b/src/SimConnect.NET/Structs/SimConnectRecvGetInputEvent.cs
@@ -10,6 +10,27 @@ namespace SimConnect.NET
     public struct SimConnectRecvGetInputEvent
     {
         /// <summary>
+        /// Gets or sets the client-defined request ID.
+        /// </summary>
+        public uint RequestId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the input event. This is used to cast the Value to the correct type.
+        /// </summary>
+        public SimConnectInputEventType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the requested input event, which should be cast to the correct format (float / string).
+        /// </summary>
+        public Object Value { get; set; }
+    }
+
+    /// <summary>
+    /// The SimConnectRecvGetInputEvent structure is used to return the value of a specific input event.
+    /// </summary>
+    public struct SimConnectRecvGetInputEventHeader
+    {
+        /// <summary>
         /// Gets or sets the total size of the returned structure in bytes.
         /// </summary>
         public uint Size { get; set; }
@@ -33,10 +54,5 @@ namespace SimConnect.NET
         /// Gets or sets the type of the input event. This is used to cast the Value to the correct type.
         /// </summary>
         public SimConnectInputEventType Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value of the requested input event, which should be cast to the correct format (float / string).
-        /// </summary>
-        public IntPtr Value { get; set; }
     }
 }

--- a/src/SimConnect.NET/Structs/SimConnectRecvGetInputEventHeader.cs
+++ b/src/SimConnect.NET/Structs/SimConnectRecvGetInputEventHeader.cs
@@ -1,4 +1,4 @@
-// <copyright file="SimConnectRecvGetInputEvent.cs" company="BARS">
+// <copyright file="SimConnectRecvGetInputEventHeader.cs" company="BARS">
 // Copyright (c) BARS. All rights reserved.
 // </copyright>
 


### PR DESCRIPTION
## Summary
Fixed GetInputEventAsync to read the Value bytes correctly based on type.

## Changes Made
Corrected the return type enum.
Added a new structure for the response without the value.
Read the bytes dynamically based on the type.
Removed an unused structure.

## Additional Information
<!-- Any other relevant information, screenshots, or context -->
Tested with:

var inputEvents = await client.InputEvents.EnumerateInputEventsAsync(cancellationToken);
foreach (var evt in inputEvents)
{
    Console.WriteLine($"      📋 InputEvent: {evt.Name}");
    var currentValue = await client.InputEvents.GetInputEventAsync(evt.Hash, cancellationToken);
    Console.WriteLine($"         📊 Current value: {currentValue}");
}

## Author Information
**Discord Username:** bstudtma

---

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
