### PR TITLE
Fix SimConnect_AddToDataDefinition to change default datumType to 4 and datumId to 0xFFFFFFFF

### DIFF
--- a/src/SimConnect.NET/SimConnectNative.cs
+++ b/src/SimConnect.NET/SimConnectNative.cs
@@ -168,9 +168,9 @@ namespace SimConnect.NET
             uint defineId,
             [MarshalAs(UnmanagedType.LPStr)] string datumName,
             [MarshalAs(UnmanagedType.LPStr)] string unitsName,
-            uint datumType = 0,
+            uint datumType = 4,
             float fEpsilon = 0,
-            uint datumId = 0);
+            uint datumId = 0xFFFFFFFFu);
 
         [DllImport("SimConnect.dll")]
         public static extern int SimConnect_SetClientData(


### PR DESCRIPTION
Fixed defaults for SimConnect_AddToDataDefinition

## Summary
Fixed defaults so to allow multiple AddToDataDefinition

Before this changed, multiple calls to AddToDataDefinition would overwrite each other even if for a different var. This fix will allow multiple vars for a single definition.

## Changes Made
Synced defaults with C:\MSFS 2024 SDK\SimConnect SDK\include\SimConnect.h

## Additional Information
This is blocking a feature branch I'm working on to allow dynamic structures.

## Author Information
**Discord Username:** bstudtma

---

### Checklist:

* [ x] Have you followed the guidelines in our Contributing document?
* [ x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
