### PR TITLE
Add facility manager API and tests

### DIFF
--- a/SimConnect.NET.sln
+++ b/SimConnect.NET.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{02EA681E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimConnect.NET.Tests.Net8", "tests\SimConnect.NET.Tests.Net8\SimConnect.NET.Tests.Net8.csproj", "{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimConnect.NET.UnitTests", "tests\SimConnect.NET.UnitTests\SimConnect.NET.UnitTests.csproj", "{A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,15 +45,28 @@ Global
 		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x64.ActiveCfg = Release|Any CPU
 		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x64.Build.0 = Release|Any CPU
-		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x86.ActiveCfg = Release|Any CPU
-		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x86.Build.0 = Release|Any CPU
+                {38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x86.ActiveCfg = Release|Any CPU
+                {38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB}.Release|x86.Build.0 = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|x64.Build.0 = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Debug|x86.Build.0 = Debug|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|x64.ActiveCfg = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|x64.Build.0 = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|x86.ActiveCfg = Release|Any CPU
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4252A45B-8C7E-487B-9670-53935D9CD06A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {38DFE777-B0F1-DC77-6E04-6DAEFC6F00DB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {A5983127-E3A8-4E4A-9F48-307DAB9B2CF0} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D38737E6-D81A-4DDE-9278-DE960E039FEB}

--- a/src/SimConnect.NET/Facilities/FacilityDataResponse.cs
+++ b/src/SimConnect.NET/Facilities/FacilityDataResponse.cs
@@ -1,0 +1,49 @@
+// <copyright file="FacilityDataResponse.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Represents the result of a facility data request. Contains one or more payloads describing the
+    /// requested facility and any child objects (runways, approaches, etc.).
+    /// </summary>
+    public sealed class FacilityDataResponse
+    {
+        internal FacilityDataResponse(uint requestId, IReadOnlyList<FacilityDataResult> results)
+        {
+            this.RequestId = requestId;
+            this.Results = results;
+        }
+
+        /// <summary>
+        /// Gets the client supplied request identifier.
+        /// </summary>
+        public uint RequestId { get; }
+
+        /// <summary>
+        /// Gets the collection of data packets returned by SimConnect.
+        /// </summary>
+        public IReadOnlyList<FacilityDataResult> Results { get; }
+
+        /// <summary>
+        /// Finds the first payload matching the specified <see cref="SimConnectFacilityDataType"/>.
+        /// </summary>
+        /// <param name="dataType">The desired data type.</param>
+        /// <returns>The payload if present; otherwise <see langword="null"/>.</returns>
+        public FacilityDataResult? Find(SimConnectFacilityDataType dataType)
+        {
+            foreach (var result in this.Results)
+            {
+                if (result.DataType == dataType)
+                {
+                    return result;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityDataResult.cs
+++ b/src/SimConnect.NET/Facilities/FacilityDataResult.cs
@@ -1,0 +1,86 @@
+// <copyright file="FacilityDataResult.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Represents a single facility data packet returned by SimConnect.
+    /// </summary>
+    public readonly struct FacilityDataResult
+    {
+        private readonly byte[] payload;
+
+        internal FacilityDataResult(
+            uint uniqueRequestId,
+            uint parentUniqueRequestId,
+            SimConnectFacilityDataType dataType,
+            bool isListItem,
+            uint itemIndex,
+            uint listSize,
+            byte[] payload)
+        {
+            this.UniqueRequestId = uniqueRequestId;
+            this.ParentUniqueRequestId = parentUniqueRequestId;
+            this.DataType = dataType;
+            this.IsListItem = isListItem;
+            this.ItemIndex = itemIndex;
+            this.ListSize = listSize;
+            this.payload = payload ?? Array.Empty<byte>();
+        }
+
+        /// <summary>
+        /// Gets the unique request identifier assigned by SimConnect.
+        /// </summary>
+        public uint UniqueRequestId { get; }
+
+        /// <summary>
+        /// Gets the parent unique request identifier, if any.
+        /// </summary>
+        public uint ParentUniqueRequestId { get; }
+
+        /// <summary>
+        /// Gets the facility data type represented by this payload.
+        /// </summary>
+        public SimConnectFacilityDataType DataType { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this payload represents an element of a list.
+        /// </summary>
+        public bool IsListItem { get; }
+
+        /// <summary>
+        /// Gets the index of the item within a list, if <see cref="IsListItem"/> is true.
+        /// </summary>
+        public uint ItemIndex { get; }
+
+        /// <summary>
+        /// Gets the total number of items in the list, if <see cref="IsListItem"/> is true.
+        /// </summary>
+        public uint ListSize { get; }
+
+        /// <summary>
+        /// Gets the raw payload memory returned by SimConnect.
+        /// </summary>
+        public ReadOnlyMemory<byte> Payload => this.payload;
+
+        /// <summary>
+        /// Marshals the payload into a managed struct of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The target struct type. Must be blittable.</typeparam>
+        /// <returns>The marshalled struct.</returns>
+        public T As<T>()
+            where T : struct
+        {
+            if (this.payload.Length < Marshal.SizeOf<T>())
+            {
+                throw new InvalidOperationException("Payload is smaller than the requested struct type.");
+            }
+
+            return MemoryMarshal.Read<T>(this.payload.AsSpan());
+        }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityDefinition.cs
+++ b/src/SimConnect.NET/Facilities/FacilityDefinition.cs
@@ -1,0 +1,37 @@
+// <copyright file="FacilityDefinition.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Represents a facility data definition registered with SimConnect.
+    /// </summary>
+    public sealed class FacilityDefinition
+    {
+        internal FacilityDefinition(uint definitionId, IReadOnlyList<string> fields, Type? structType)
+        {
+            this.DefinitionId = definitionId;
+            this.Fields = fields;
+            this.StructType = structType;
+        }
+
+        /// <summary>
+        /// Gets the SimConnect definition identifier.
+        /// </summary>
+        public uint DefinitionId { get; }
+
+        /// <summary>
+        /// Gets the list of facility fields that are part of this definition.
+        /// </summary>
+        public IReadOnlyList<string> Fields { get; }
+
+        /// <summary>
+        /// Gets the struct type used to generate this definition, if any.
+        /// </summary>
+        public Type? StructType { get; }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityDefinitionBuilder.cs
+++ b/src/SimConnect.NET/Facilities/FacilityDefinitionBuilder.cs
@@ -1,0 +1,35 @@
+// <copyright file="FacilityDefinitionBuilder.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Fluent builder for <see cref="FacilityDefinition"/> instances.
+    /// </summary>
+    public sealed class FacilityDefinitionBuilder
+    {
+        private readonly List<string> fields = new();
+
+        /// <summary>
+        /// Gets the configured field list.
+        /// </summary>
+        internal IReadOnlyList<string> Fields => this.fields;
+
+        /// <summary>
+        /// Adds a field path to the definition.
+        /// </summary>
+        /// <param name="fieldPath">The SimConnect facility field path (for example "Airport.Latitude").</param>
+        /// <returns>The same builder instance to allow fluent chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldPath"/> is null or whitespace.</exception>
+        public FacilityDefinitionBuilder AddField(string fieldPath)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(fieldPath);
+            this.fields.Add(fieldPath);
+            return this;
+        }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityFieldAttribute.cs
+++ b/src/SimConnect.NET/Facilities/FacilityFieldAttribute.cs
@@ -1,0 +1,37 @@
+// <copyright file="FacilityFieldAttribute.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Annotates a struct field with a SimConnect facility field path for automatic definition creation.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class FacilityFieldAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FacilityFieldAttribute"/> class.
+        /// </summary>
+        /// <param name="path">The SimConnect facility field path.</param>
+        /// <param name="order">Optional explicit ordering (lower numbers are processed first).</param>
+        public FacilityFieldAttribute(string path, int order = 0)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+            this.Path = path;
+            this.Order = order;
+        }
+
+        /// <summary>
+        /// Gets the SimConnect facility field path represented by this attribute.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Gets the optional ordering index. Lower values are processed first.
+        /// </summary>
+        public int Order { get; }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityManager.cs
+++ b/src/SimConnect.NET/Facilities/FacilityManager.cs
@@ -1,0 +1,514 @@
+// <copyright file="FacilityManager.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using SimConnect.NET.Internal;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Provides high-level helpers for working with the SimConnect facility APIs, including
+    /// dynamic data definitions, ad-hoc facility data requests, and in-range subscriptions.
+    /// </summary>
+    public sealed class FacilityManager : IDisposable
+    {
+        private const uint BaseDefinitionId = 50000;
+        private const uint BaseRequestId = 60000;
+
+        private readonly IntPtr simConnectHandle;
+        private readonly ISimConnectFacilityApi facilityApi;
+        private readonly ConcurrentDictionary<Type, FacilityDefinition> definitionCache = new();
+        private readonly ConcurrentDictionary<uint, FacilityMinimalListRequest> minimalListRequests = new();
+        private readonly ConcurrentDictionary<uint, FacilityDataRequestState> facilityDataRequests = new();
+        private readonly ConcurrentDictionary<SimConnectFacilityListType, FacilitySubscription> activeSubscriptions = new();
+        private readonly ConcurrentDictionary<uint, FacilitySubscription> subscriptionLookup = new();
+        private int definitionCounter = (int)BaseDefinitionId - 1;
+        private int requestCounter = (int)BaseRequestId - 1;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FacilityManager"/> class.
+        /// </summary>
+        /// <param name="simConnectHandle">The active SimConnect handle.</param>
+        public FacilityManager(IntPtr simConnectHandle)
+            : this(simConnectHandle, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FacilityManager"/> class for testing.
+        /// </summary>
+        /// <param name="simConnectHandle">The active SimConnect handle.</param>
+        /// <param name="facilityApi">Optional facility API abstraction used for testing.</param>
+        internal FacilityManager(IntPtr simConnectHandle, ISimConnectFacilityApi? facilityApi)
+        {
+            if (simConnectHandle == IntPtr.Zero)
+            {
+                throw new ArgumentException("SimConnect handle must be initialized.", nameof(simConnectHandle));
+            }
+
+            this.simConnectHandle = simConnectHandle;
+            this.facilityApi = facilityApi ?? SimConnectFacilityApi.Instance;
+        }
+
+        /// <summary>
+        /// Creates a facility definition from the supplied builder configuration.
+        /// </summary>
+        /// <param name="configure">Action that defines the desired facility fields.</param>
+        /// <returns>A <see cref="FacilityDefinition"/> instance bound to a SimConnect definition ID.</returns>
+        public FacilityDefinition CreateDefinition(Action<FacilityDefinitionBuilder> configure)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, nameof(FacilityManager));
+            ArgumentNullException.ThrowIfNull(configure);
+
+            var builder = new FacilityDefinitionBuilder();
+            configure(builder);
+            if (builder.Fields.Count == 0)
+            {
+                throw new InvalidOperationException("At least one facility field must be added to the definition.");
+            }
+
+            var definitionId = this.GetNextDefinitionId();
+            foreach (var field in builder.Fields)
+            {
+                ThrowIfError(
+                    this.facilityApi.AddToFacilityDefinition(this.simConnectHandle, definitionId, field),
+                    $"Add facility field '{field}'");
+            }
+
+            return new FacilityDefinition(definitionId, builder.Fields.ToArray(), null);
+        }
+
+        /// <summary>
+        /// Creates or retrieves a cached facility definition using <see cref="FacilityFieldAttribute"/> annotations.
+        /// </summary>
+        /// <typeparam name="T">Struct containing annotated fields.</typeparam>
+        /// <returns>The cached <see cref="FacilityDefinition"/>.</returns>
+        public FacilityDefinition GetOrCreateDefinition<T>()
+            where T : struct
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, nameof(FacilityManager));
+            return this.definitionCache.GetOrAdd(typeof(T), _ => this.CreateDefinitionFromStruct<T>());
+        }
+
+        /// <summary>
+        /// Requests facility data using a previously created definition.
+        /// </summary>
+        /// <param name="definition">The facility definition to use.</param>
+        /// <param name="icao">The ICAO identifier of the facility.</param>
+        /// <param name="region">Optional region string.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task returning the full response payload.</returns>
+        public Task<FacilityDataResponse> RequestFacilityDataAsync(
+            FacilityDefinition definition,
+            string icao,
+            string? region = null,
+            CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, nameof(FacilityManager));
+            ArgumentNullException.ThrowIfNull(definition);
+            ArgumentException.ThrowIfNullOrEmpty(icao);
+
+            var requestId = this.GetNextRequestId();
+            var requestState = new FacilityDataRequestState(requestId);
+            if (!this.facilityDataRequests.TryAdd(requestId, requestState))
+            {
+                throw new InvalidOperationException("Failed to track facility data request state.");
+            }
+
+            cancellationToken.Register(() =>
+            {
+                if (this.facilityDataRequests.TryRemove(requestId, out var canceled))
+                {
+                    canceled.TrySetCanceled();
+                }
+            });
+
+            ThrowIfError(
+                this.facilityApi.RequestFacilityData(this.simConnectHandle, definition.DefinitionId, requestId, icao, region ?? string.Empty),
+                "RequestFacilityData");
+
+            return requestState.Task;
+        }
+
+        /// <summary>
+        /// Requests facility data for the specified annotated struct type.
+        /// </summary>
+        /// <typeparam name="T">The annotated struct type describing the desired fields.</typeparam>
+        /// <param name="icao">The ICAO identifier.</param>
+        /// <param name="region">Optional region code.</param>
+        /// <param name="cancellationToken">Cancellation token for the request.</param>
+        /// <returns>The complete <see cref="FacilityDataResponse"/>.</returns>
+        public Task<FacilityDataResponse> RequestFacilityDataAsync<T>(
+            string icao,
+            string? region = null,
+            CancellationToken cancellationToken = default)
+            where T : struct
+            => this.RequestFacilityDataAsync(this.GetOrCreateDefinition<T>(), icao, region, cancellationToken);
+
+        /// <summary>
+        /// Requests the minimal facility list (ICAO and Lat/Lon/Alt) for the specified type.
+        /// </summary>
+        /// <param name="type">The facility list type (airport, waypoint, etc.).</param>
+        /// <param name="cancellationToken">Cancellation token for the request.</param>
+        /// <returns>A task that completes with the full list of facilities.</returns>
+        public Task<IReadOnlyList<SimConnectFacilityMinimal>> RequestMinimalListAsync(
+            SimConnectFacilityListType type,
+            CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, nameof(FacilityManager));
+            var requestId = this.GetNextRequestId();
+            var state = new FacilityMinimalListRequest(requestId);
+            if (!this.minimalListRequests.TryAdd(requestId, state))
+            {
+                throw new InvalidOperationException("Failed to track facility list request state.");
+            }
+
+            cancellationToken.Register(() =>
+            {
+                if (this.minimalListRequests.TryRemove(requestId, out var canceled))
+                {
+                    canceled.TrySetCanceled();
+                }
+            });
+
+            ThrowIfError(
+                this.facilityApi.RequestFacilitiesListEx1(this.simConnectHandle, (uint)type, requestId),
+                "RequestFacilitiesList_EX1");
+
+            return state.Task;
+        }
+
+        /// <summary>
+        /// Subscribes to facilities entering and leaving the user's reality bubble.
+        /// </summary>
+        /// <param name="type">Facility list type to monitor.</param>
+        /// <param name="onEntered">Callback invoked when facilities enter range.</param>
+        /// <param name="onExited">Optional callback for facilities leaving range.</param>
+        /// <returns>A disposable subscription object.</returns>
+        public FacilitySubscription SubscribeToMinimalFacilities(
+            SimConnectFacilityListType type,
+            Action<IReadOnlyList<SimConnectFacilityMinimal>> onEntered,
+            Action<IReadOnlyList<SimConnectFacilityMinimal>>? onExited = null)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, nameof(FacilityManager));
+            ArgumentNullException.ThrowIfNull(onEntered);
+
+            var inRangeRequestId = this.GetNextRequestId();
+            var outRangeRequestId = this.GetNextRequestId();
+            var subscription = new FacilitySubscription(this, type, inRangeRequestId, outRangeRequestId, onEntered, onExited);
+
+            if (!this.activeSubscriptions.TryAdd(type, subscription))
+            {
+                throw new InvalidOperationException($"A subscription for {type} already exists. Dispose the existing subscription before creating a new one.");
+            }
+
+            this.subscriptionLookup[inRangeRequestId] = subscription;
+            this.subscriptionLookup[outRangeRequestId] = subscription;
+
+            try
+            {
+                ThrowIfError(
+                    this.facilityApi.SubscribeToFacilitiesEx1(this.simConnectHandle, (uint)type, inRangeRequestId, outRangeRequestId),
+                    "SubscribeToFacilities_EX1");
+            }
+            catch
+            {
+                this.subscriptionLookup.TryRemove(inRangeRequestId, out _);
+                this.subscriptionLookup.TryRemove(outRangeRequestId, out _);
+                this.activeSubscriptions.TryRemove(type, out _);
+                throw;
+            }
+
+            return subscription;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            foreach (var subscription in this.activeSubscriptions.Values)
+            {
+                subscription?.Dispose();
+            }
+
+            this.disposed = true;
+        }
+
+        internal void RemoveSubscription(FacilitySubscription subscription)
+        {
+            if (subscription == null)
+            {
+                return;
+            }
+
+            this.subscriptionLookup.TryRemove(subscription.EnteredRequestId, out _);
+            this.subscriptionLookup.TryRemove(subscription.ExitedRequestId, out _);
+            this.activeSubscriptions.TryRemove(subscription.Type, out _);
+            try
+            {
+                ThrowIfError(
+                    this.facilityApi.UnsubscribeFromFacilitiesEx1(this.simConnectHandle, (uint)subscription.Type, true, true),
+                    "UnsubscribeToFacilities_EX1");
+            }
+            catch (SimConnectException ex) when (!ExceptionHelper.IsCritical(ex))
+            {
+                SimConnectLogger.Warning($"Failed to unsubscribe from facilities: {ex.Message}");
+            }
+        }
+
+        internal void ProcessFacilityMinimalList(IntPtr data)
+        {
+            if (data == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var header = Marshal.PtrToStructure<FacilityMinimalListHeader>(data)!;
+            var dataStart = IntPtr.Add(data, FacilityMinimalListHeader.SizeInBytes);
+            var list = FacilityManager.MarshalArray<SimConnectFacilityMinimal>(dataStart, (int)header.ArraySize);
+
+            if (this.subscriptionLookup.TryGetValue(header.RequestId, out var subscription))
+            {
+                subscription.Dispatch(header.RequestId, list);
+                return;
+            }
+
+            if (this.minimalListRequests.TryGetValue(header.RequestId, out var request))
+            {
+                request.AddChunk(list, header.EntryNumber, header.OutOf);
+                if (request.IsComplete)
+                {
+                    this.minimalListRequests.TryRemove(header.RequestId, out _);
+                }
+
+                return;
+            }
+        }
+
+        internal void ProcessFacilityData(IntPtr data)
+        {
+            if (data == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var recv = Marshal.PtrToStructure<SimConnectRecvFacilityDataInternal>(data)!;
+            if (this.facilityDataRequests.TryGetValue(recv.UserRequestId, out var state))
+            {
+                state.AddPacket(data, recv);
+            }
+        }
+
+        internal void ProcessFacilityDataEnd(IntPtr data)
+        {
+            if (data == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var recvEnd = Marshal.PtrToStructure<SimConnectRecvFacilityDataEnd>(data)!;
+            if (this.facilityDataRequests.TryRemove(recvEnd.RequestId, out var state))
+            {
+                state.Complete();
+            }
+        }
+
+        private static void ThrowIfError(int result, string operation)
+        {
+            if (result == (int)SimConnectError.None)
+            {
+                return;
+            }
+
+            var error = (SimConnectError)result;
+            var message = $"{operation} failed: {SimConnectErrorMapper.Describe(error)}";
+            throw new SimConnectException(message, error);
+        }
+
+        private static T[] MarshalArray<T>(IntPtr dataStart, int count)
+            where T : struct
+        {
+            if (count <= 0 || dataStart == IntPtr.Zero)
+            {
+                return Array.Empty<T>();
+            }
+
+            var elementSize = Marshal.SizeOf<T>();
+            var result = new T[count];
+            for (var i = 0; i < count; i++)
+            {
+                var elementPtr = IntPtr.Add(dataStart, i * elementSize);
+                result[i] = Marshal.PtrToStructure<T>(elementPtr)!;
+            }
+
+            return result;
+        }
+
+        private FacilityDefinition CreateDefinitionFromStruct<T>()
+            where T : struct
+        {
+            var fields = typeof(T)
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Select(f => (Field: f, Attribute: f.GetCustomAttribute<FacilityFieldAttribute>()))
+                .Where(tuple => tuple.Attribute != null)
+                .OrderBy(tuple => tuple.Attribute!.Order)
+                .ThenBy(tuple => tuple.Field.MetadataToken)
+                .Select(tuple => tuple.Attribute!.Path)
+                .ToList();
+
+            if (fields.Count == 0)
+            {
+                throw new InvalidOperationException($"Type {typeof(T).FullName} does not define any FacilityFieldAttribute annotations.");
+            }
+
+            var definitionId = this.GetNextDefinitionId();
+            foreach (var field in fields)
+            {
+                ThrowIfError(
+                    this.facilityApi.AddToFacilityDefinition(this.simConnectHandle, definitionId, field),
+                    $"Add facility field '{field}'");
+            }
+
+            return new FacilityDefinition(definitionId, fields, typeof(T));
+        }
+
+        private uint GetNextDefinitionId() => (uint)Interlocked.Increment(ref this.definitionCounter);
+
+        private uint GetNextRequestId() => (uint)Interlocked.Increment(ref this.requestCounter);
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct FacilityMinimalListHeader
+        {
+            public static readonly int SizeInBytes = Marshal.SizeOf<FacilityMinimalListHeader>();
+
+            public uint Size;
+            public uint Version;
+            public uint Id;
+            public uint RequestId;
+            public uint ArraySize;
+            public uint EntryNumber;
+            public uint OutOf;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct SimConnectRecvFacilityDataInternal
+        {
+            public static readonly int DataOffset = Marshal.OffsetOf<SimConnectRecvFacilityDataInternal>(nameof(Data)).ToInt32();
+
+            public uint Size;
+            public uint Version;
+            public uint Id;
+            public uint UserRequestId;
+            public uint UniqueRequestId;
+            public uint ParentUniqueRequestId;
+            public SimConnectFacilityDataType Type;
+            public uint IsListItem;
+            public uint ItemIndex;
+            public uint ListSize;
+            public uint Data;
+        }
+
+        private sealed class FacilityMinimalListRequest
+        {
+            private readonly TaskCompletionSource<IReadOnlyList<SimConnectFacilityMinimal>> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly List<SimConnectFacilityMinimal> buffer = new();
+            private uint expectedPackets;
+            private uint receivedPackets;
+
+            internal FacilityMinimalListRequest(uint requestId)
+            {
+            }
+
+            internal Task<IReadOnlyList<SimConnectFacilityMinimal>> Task => this.tcs.Task;
+
+            internal bool IsComplete => this.expectedPackets != 0 && this.receivedPackets >= this.expectedPackets;
+
+            internal void AddChunk(IReadOnlyList<SimConnectFacilityMinimal> chunk, uint entryNumber, uint outOf)
+            {
+                if (chunk.Count > 0)
+                {
+                    this.buffer.AddRange(chunk);
+                }
+
+                this.receivedPackets++;
+                this.expectedPackets = outOf == 0 ? 1u : outOf;
+
+                if (this.IsComplete)
+                {
+                    this.tcs.TrySetResult(this.buffer);
+                }
+            }
+
+            internal void TrySetCanceled()
+            {
+                this.tcs.TrySetCanceled();
+            }
+        }
+
+        private sealed class FacilityDataRequestState
+        {
+            private readonly TaskCompletionSource<FacilityDataResponse> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly List<FacilityDataResult> packets = new();
+            private readonly uint requestId;
+
+            internal FacilityDataRequestState(uint requestId)
+            {
+                this.requestId = requestId;
+            }
+
+            internal Task<FacilityDataResponse> Task => this.tcs.Task;
+
+            internal void AddPacket(IntPtr basePtr, SimConnectRecvFacilityDataInternal data)
+            {
+                var payloadSize = (int)data.Size - SimConnectRecvFacilityDataInternal.DataOffset;
+                if (payloadSize < 0)
+                {
+                    payloadSize = 0;
+                }
+
+                var payload = new byte[payloadSize];
+                if (payloadSize > 0)
+                {
+                    var payloadPtr = IntPtr.Add(basePtr, SimConnectRecvFacilityDataInternal.DataOffset);
+                    Marshal.Copy(payloadPtr, payload, 0, payloadSize);
+                }
+
+                var result = new FacilityDataResult(
+                    data.UniqueRequestId,
+                    data.ParentUniqueRequestId,
+                    data.Type,
+                    data.IsListItem != 0,
+                    data.ItemIndex,
+                    data.ListSize,
+                    payload);
+
+                this.packets.Add(result);
+            }
+
+            internal void Complete()
+            {
+                this.tcs.TrySetResult(new FacilityDataResponse(this.requestId, this.packets));
+            }
+
+            internal void TrySetCanceled()
+            {
+                this.tcs.TrySetCanceled();
+            }
+        }
+    }
+}

--- a/src/SimConnect.NET/Facilities/FacilityManager.cs
+++ b/src/SimConnect.NET/Facilities/FacilityManager.cs
@@ -438,9 +438,9 @@ namespace SimConnect.NET.Facilities
 
             internal bool IsComplete => this.expectedPackets != 0 && this.receivedPackets >= this.expectedPackets;
 
-            internal void AddChunk(IReadOnlyList<SimConnectFacilityMinimal> chunk, uint entryNumber, uint outOf)
+            internal void AddChunk(SimConnectFacilityMinimal[] chunk, uint entryNumber, uint outOf)
             {
-                if (chunk.Count > 0)
+                if (chunk.Length > 0)
                 {
                     this.buffer.AddRange(chunk);
                 }

--- a/src/SimConnect.NET/Facilities/FacilitySubscription.cs
+++ b/src/SimConnect.NET/Facilities/FacilitySubscription.cs
@@ -1,0 +1,70 @@
+// <copyright file="FacilitySubscription.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace SimConnect.NET.Facilities
+{
+    /// <summary>
+    /// Represents an active subscription created through <see cref="FacilityManager.SubscribeToMinimalFacilities"/>.
+    /// </summary>
+    public sealed class FacilitySubscription : IDisposable
+    {
+        private readonly FacilityManager manager;
+        private readonly Action<IReadOnlyList<SimConnectFacilityMinimal>> onEntered;
+        private readonly Action<IReadOnlyList<SimConnectFacilityMinimal>>? onExited;
+        private bool disposed;
+
+        internal FacilitySubscription(
+            FacilityManager manager,
+            SimConnectFacilityListType type,
+            uint enteredRequestId,
+            uint exitedRequestId,
+            Action<IReadOnlyList<SimConnectFacilityMinimal>> onEntered,
+            Action<IReadOnlyList<SimConnectFacilityMinimal>>? onExited)
+        {
+            this.manager = manager;
+            this.Type = type;
+            this.EnteredRequestId = enteredRequestId;
+            this.ExitedRequestId = exitedRequestId;
+            this.onEntered = onEntered ?? throw new ArgumentNullException(nameof(onEntered));
+            this.onExited = onExited;
+        }
+
+        /// <summary>
+        /// Gets the facility type represented by the subscription.
+        /// </summary>
+        public SimConnectFacilityListType Type { get; }
+
+        internal uint EnteredRequestId { get; }
+
+        internal uint ExitedRequestId { get; }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.manager.RemoveSubscription(this);
+            GC.SuppressFinalize(this);
+        }
+
+        internal void Dispatch(uint requestId, IReadOnlyList<SimConnectFacilityMinimal> facilities)
+        {
+            if (requestId == this.EnteredRequestId)
+            {
+                this.onEntered(facilities);
+            }
+            else if (requestId == this.ExitedRequestId)
+            {
+                this.onExited?.Invoke(facilities);
+            }
+        }
+    }
+}

--- a/src/SimConnect.NET/Internal/ISimConnectFacilityApi.cs
+++ b/src/SimConnect.NET/Internal/ISimConnectFacilityApi.cs
@@ -1,0 +1,125 @@
+// <copyright file="ISimConnectFacilityApi.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace SimConnect.NET.Internal
+{
+    /// <summary>
+    /// Abstraction over the SimConnect facility P/Invoke surface.
+    /// </summary>
+    internal interface ISimConnectFacilityApi
+    {
+        /// <summary>Adds a field to a facility definition.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="definitionId">Target facility definition identifier.</param>
+        /// <param name="fieldName">The field path to add.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int AddToFacilityDefinition(IntPtr handle, uint definitionId, string fieldName);
+
+        /// <summary>Requests facility data using a definition.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="definitionId">Definition identifier.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <param name="icao">Facility ICAO code.</param>
+        /// <param name="region">Optional region code.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int RequestFacilityData(IntPtr handle, uint definitionId, uint requestId, string icao, string region);
+
+        /// <summary>Requests a facility list using the legacy API.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int RequestFacilitiesList(IntPtr handle, uint type, uint requestId);
+
+        /// <summary>Requests a facility list using the EX1 API.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int RequestFacilitiesListEx1(IntPtr handle, uint type, uint requestId);
+
+        /// <summary>Subscribes to facilities entering/exiting range.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="newInRangeRequestId">Request ID for entries entering range.</param>
+        /// <param name="oldOutRangeRequestId">Request ID for entries leaving range.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int SubscribeToFacilitiesEx1(IntPtr handle, uint type, uint newInRangeRequestId, uint oldOutRangeRequestId);
+
+        /// <summary>Unsubscribes from facility notifications.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="unsubscribeNewInRange">Whether to unsubscribe from new-in-range events.</param>
+        /// <param name="unsubscribeOldOutRange">Whether to unsubscribe from out-of-range events.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        int UnsubscribeFromFacilitiesEx1(IntPtr handle, uint type, bool unsubscribeNewInRange, bool unsubscribeOldOutRange);
+    }
+
+    /// <summary>
+    /// Default implementation that forwards calls to <see cref="SimConnectNative"/>.
+    /// </summary>
+    internal sealed class SimConnectFacilityApi : ISimConnectFacilityApi
+    {
+        private SimConnectFacilityApi()
+        {
+        }
+
+        /// <summary>Gets the shared singleton instance.</summary>
+        public static ISimConnectFacilityApi Instance { get; } = new SimConnectFacilityApi();
+
+        /// <summary>Adds a field to a facility definition.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="definitionId">Target facility definition identifier.</param>
+        /// <param name="fieldName">The field path to add.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int AddToFacilityDefinition(IntPtr handle, uint definitionId, string fieldName)
+            => SimConnectNative.SimConnect_AddToFacilityDefinition(handle, definitionId, fieldName);
+
+        /// <summary>Requests facility data using a definition.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="definitionId">Definition identifier.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <param name="icao">Facility ICAO code.</param>
+        /// <param name="region">Optional region code.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int RequestFacilityData(IntPtr handle, uint definitionId, uint requestId, string icao, string region)
+            => SimConnectNative.SimConnect_RequestFacilityData(handle, definitionId, requestId, icao, region ?? string.Empty);
+
+        /// <summary>Requests a facility list using the legacy API.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int RequestFacilitiesList(IntPtr handle, uint type, uint requestId)
+            => SimConnectNative.SimConnect_RequestFacilitiesList(handle, type, requestId);
+
+        /// <summary>Requests a facility list using the EX1 API.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="requestId">Client request identifier.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int RequestFacilitiesListEx1(IntPtr handle, uint type, uint requestId)
+            => SimConnectNative.SimConnect_RequestFacilitiesList_EX1(handle, type, requestId);
+
+        /// <summary>Subscribes to facilities entering/exiting range.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="newInRangeRequestId">Request ID for entries entering range.</param>
+        /// <param name="oldOutRangeRequestId">Request ID for entries leaving range.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int SubscribeToFacilitiesEx1(IntPtr handle, uint type, uint newInRangeRequestId, uint oldOutRangeRequestId)
+            => SimConnectNative.SimConnect_SubscribeToFacilities_EX1(handle, type, newInRangeRequestId, oldOutRangeRequestId);
+
+        /// <summary>Unsubscribes from facility notifications.</summary>
+        /// <param name="handle">Active SimConnect handle.</param>
+        /// <param name="type">Facility list type.</param>
+        /// <param name="unsubscribeNewInRange">Whether to unsubscribe from new-in-range events.</param>
+        /// <param name="unsubscribeOldOutRange">Whether to unsubscribe from out-of-range events.</param>
+        /// <returns>The raw SimConnect result.</returns>
+        public int UnsubscribeFromFacilitiesEx1(IntPtr handle, uint type, bool unsubscribeNewInRange, bool unsubscribeOldOutRange)
+            => SimConnectNative.SimConnect_UnsubscribeToFacilities_EX1(handle, type, unsubscribeNewInRange, unsubscribeOldOutRange);
+    }
+}

--- a/src/SimConnect.NET/Properties/AssemblyInfo.cs
+++ b/src/SimConnect.NET/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// <copyright file="AssemblyInfo.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SimConnect.NET.UnitTests")]

--- a/src/SimConnect.NET/SimConnectClient.cs
+++ b/src/SimConnect.NET/SimConnectClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using SimConnect.NET.AI;
 using SimConnect.NET.Aircraft;
 using SimConnect.NET.Events;
+using SimConnect.NET.Facilities;
 using SimConnect.NET.InputEvents;
 using SimConnect.NET.Internal;
 using SimConnect.NET.SimVar;
@@ -31,6 +32,7 @@ namespace SimConnect.NET
         private SimObjectManager? simObjectManager;
         private InputEventManager? inputEventManager;
         private InputGroupManager? inputGroupManager;
+        private FacilityManager? facilityManager;
         private int reconnectAttempts;
         private Task? reconnectTask;
         private CancellationTokenSource? reconnectCancellation;
@@ -194,6 +196,23 @@ namespace SimConnect.NET
         }
 
         /// <summary>
+        /// Gets the facility manager for querying and subscribing to facility data.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when not connected to SimConnect.</exception>
+        public FacilityManager Facilities
+        {
+            get
+            {
+                if (!this.isConnected || this.facilityManager == null)
+                {
+                    throw new InvalidOperationException("Not connected to SimConnect. Call ConnectAsync first.");
+                }
+
+                return this.facilityManager;
+            }
+        }
+
+        /// <summary>
         /// Gets the SimConnect handle for advanced operations.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when not connected to SimConnect.</exception>
@@ -254,6 +273,7 @@ namespace SimConnect.NET
             this.simObjectManager = new SimObjectManager(this);
             this.inputEventManager = new InputEventManager(this.simConnectHandle);
             this.inputGroupManager = new InputGroupManager(this.simConnectHandle);
+            this.facilityManager = new FacilityManager(this.simConnectHandle);
 
             this.messageLoopCancellation = new CancellationTokenSource();
             this.messageProcessingTask = this.StartMessageProcessingLoopAsync(this.messageLoopCancellation.Token);
@@ -276,12 +296,14 @@ namespace SimConnect.NET
             this.simVarManager?.Dispose();
             this.inputEventManager?.Dispose();
             this.inputGroupManager?.Dispose();
+            this.facilityManager?.Dispose();
             this.simObjectManager = null;
             this.isMSFS2024 = false;
             this.simVarManager = null;
             this.aircraftDataManager = null;
             this.inputEventManager = null;
             this.inputGroupManager = null;
+            this.facilityManager = null;
 
             if (this.messageLoopCancellation != null)
             {
@@ -414,6 +436,15 @@ namespace SimConnect.NET
                             case SimConnectRecvId.GetInputEvent:
                             case SimConnectRecvId.SubscribeInputEvent:
                                 this.inputEventManager?.ProcessReceivedData(ppData, pcbData);
+                                break;
+                            case SimConnectRecvId.FacilityMinimalList:
+                                this.facilityManager?.ProcessFacilityMinimalList(ppData);
+                                break;
+                            case SimConnectRecvId.FacilityData:
+                                this.facilityManager?.ProcessFacilityData(ppData);
+                                break;
+                            case SimConnectRecvId.FacilityDataEnd:
+                                this.facilityManager?.ProcessFacilityDataEnd(ppData);
                                 break;
                             case SimConnectRecvId.AirportList:
                             case SimConnectRecvId.VorList:

--- a/src/SimConnect.NET/Structs/SimConnectIcao.cs
+++ b/src/SimConnect.NET/Structs/SimConnectIcao.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SimConnect.NET
 {
@@ -12,24 +13,82 @@ namespace SimConnect.NET
     [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi)]
     public struct SimConnectIcao
     {
-        /// <summary>
-        /// The type of the ICAO code.
-        /// </summary>
-        public char Type;
+        private const int IcaoSize = 9;
+        private const int IdentSize = 9;
+        private const int RegionSize = 9;
+        private const int AirportSize = 5;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IcaoSize)]
+        private byte[]? icao;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IdentSize)]
+        private byte[]? ident;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = RegionSize)]
+        private byte[]? region;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = AirportSize)]
+        private byte[]? airport;
 
         /// <summary>
-        /// The identity string (fixed 6 characters).
+        /// Gets the ICAO identifier (e.g. "KJFK").
         /// </summary>
-        public char Ident;
+        public string Icao => Decode(this.icao);
 
         /// <summary>
-        /// The region string (fixed 3 characters).
+        /// Gets the facility ident (e.g. runway or navaid name).
         /// </summary>
-        public char Region;
+        public string Ident => Decode(this.ident);
 
         /// <summary>
-        /// The airport string (fixed 5 characters).
+        /// Gets the region (State/area) code.
         /// </summary>
-        public char Airport;
+        public string Region => Decode(this.region);
+
+        /// <summary>
+        /// Gets the airport identifier if the facility belongs to an airport.
+        /// </summary>
+        public string Airport => Decode(this.airport);
+
+        /// <summary>
+        /// Creates a new <see cref="SimConnectIcao"/> instance from strings.
+        /// </summary>
+        /// <param name="icao">ICAO identifier.</param>
+        /// <param name="ident">Facility ident.</param>
+        /// <param name="region">Region code.</param>
+        /// <param name="airport">Airport identifier.</param>
+        /// <returns>A populated <see cref="SimConnectIcao"/>.</returns>
+        public static SimConnectIcao FromStrings(string? icao, string? ident = null, string? region = null, string? airport = null)
+        {
+            return new SimConnectIcao
+            {
+                icao = Encode(IcaoSize, icao),
+                ident = Encode(IdentSize, ident),
+                region = Encode(RegionSize, region),
+                airport = Encode(AirportSize, airport),
+            };
+        }
+
+        private static string Decode(byte[]? buffer)
+        {
+            if (buffer == null || buffer.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.ASCII.GetString(buffer).TrimEnd('\0', ' ');
+        }
+
+        private static byte[] Encode(int size, string? value)
+        {
+            var buffer = new byte[size];
+            if (!string.IsNullOrEmpty(value))
+            {
+                var bytes = Encoding.ASCII.GetBytes(value);
+                Array.Copy(bytes, buffer, Math.Min(bytes.Length, size - 1));
+            }
+
+            return buffer;
+        }
     }
 }

--- a/tests/SimConnect.NET.UnitTests/FacilityManagerTests.cs
+++ b/tests/SimConnect.NET.UnitTests/FacilityManagerTests.cs
@@ -1,0 +1,401 @@
+// <copyright file="FacilityManagerTests.cs" company="BARS">
+// Copyright (c) BARS. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using SimConnect.NET;
+using SimConnect.NET.Facilities;
+using SimConnect.NET.Internal;
+using Xunit;
+
+namespace SimConnect.NET.UnitTests
+{
+    /// <summary>
+    /// Unit tests exercising the <see cref="FacilityManager"/> surface.
+    /// </summary>
+    public class FacilityManagerTests
+    {
+        /// <summary>
+        /// Verifies that custom definitions register every requested field.
+        /// </summary>
+        [Fact]
+        public void CreateDefinition_RegistersAllFields()
+        {
+            var api = new FakeFacilityApi();
+            using var manager = new FacilityManager(new IntPtr(1), api);
+
+            var definition = manager.CreateDefinition(builder => builder.AddField("Airport.Latitude").AddField("Airport.Longitude"));
+
+            Assert.Equal(2, api.AddedFields.Count);
+            Assert.Equal(definition.DefinitionId, api.AddedFields[0].DefinitionId);
+        }
+
+        /// <summary>
+        /// Ensures that minimal facility list requests complete when data arrives.
+        /// </summary>
+        /// <returns>A task that completes when the test has validated the behavior.</returns>
+        [Fact]
+        public async Task MinimalListRequest_CompletesWhenMessageArrives()
+        {
+            var api = new FakeFacilityApi();
+            using var manager = new FacilityManager(new IntPtr(1), api);
+
+            var requestTask = manager.RequestMinimalListAsync(SimConnectFacilityListType.Airport);
+            var requestId = api.MinimalRequests.Single().RequestId;
+            var facilities = new[]
+            {
+                new SimConnectFacilityMinimal
+                {
+                    Icao = SimConnectIcao.FromStrings("KJFK"),
+                    LatLonAlt = new SimConnectDataLatLonAlt { Latitude = 40.64, Longitude = -73.78, Altitude = 13 },
+                },
+            };
+
+            using (var message = FacilityMessageBuilder.CreateMinimalListMessage(requestId, facilities))
+            {
+                manager.ProcessFacilityMinimalList(message.Pointer);
+            }
+
+            var result = await requestTask;
+            Assert.Single(result);
+            Assert.Equal("KJFK", result[0].Icao.Icao);
+        }
+
+        /// <summary>
+        /// Validates that facility data requests return all received payloads.
+        /// </summary>
+        /// <returns>A task that completes when the test has validated the behavior.</returns>
+        [Fact]
+        public async Task FacilityDataRequest_ReturnsPayloads()
+        {
+            var api = new FakeFacilityApi();
+            using var manager = new FacilityManager(new IntPtr(1), api);
+
+            var definition = manager.CreateDefinition(b => b.AddField("Airport.Name"));
+            var task = manager.RequestFacilityDataAsync(definition, "TEST");
+            var request = api.DataRequests.Single();
+            Assert.Equal("TEST", request.Icao);
+
+            var payload = new byte[16];
+            for (int i = 0; i < payload.Length; i++)
+            {
+                payload[i] = (byte)(i + 1);
+            }
+
+            using (var message = FacilityMessageBuilder.CreateFacilityDataMessage(request.RequestId, SimConnectFacilityDataType.Airport, payload))
+            {
+                manager.ProcessFacilityData(message.Pointer);
+            }
+
+            var end = new SimConnectRecvFacilityDataEnd
+            {
+                Size = (uint)Marshal.SizeOf<SimConnectRecvFacilityDataEnd>(),
+                Version = 1,
+                Id = (uint)SimConnectRecvId.FacilityDataEnd,
+                RequestId = request.RequestId,
+            };
+
+            IntPtr endPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SimConnectRecvFacilityDataEnd>());
+            try
+            {
+                Marshal.StructureToPtr(end, endPtr, false);
+                manager.ProcessFacilityDataEnd(endPtr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(endPtr);
+            }
+
+            var response = await task;
+            Assert.Single(response.Results);
+            Assert.Equal(payload, response.Results[0].Payload.ToArray());
+        }
+
+        /// <summary>
+        /// Ensures that subscription callbacks fire when facilities enter and exit range.
+        /// </summary>
+        [Fact]
+        public void Subscription_DispatchesCallbacks()
+        {
+            var api = new FakeFacilityApi();
+            using var manager = new FacilityManager(new IntPtr(1), api);
+
+            List<string> entered = new();
+            List<string> exited = new();
+
+            using var subscription = manager.SubscribeToMinimalFacilities(
+                SimConnectFacilityListType.Airport,
+                facilities => entered.AddRange(facilities.Select(f => f.Icao.Icao)),
+                facilities => exited.AddRange(facilities.Select(f => f.Icao.Icao)));
+
+            var entry = api.Subscriptions.Single();
+            var facilities = new[]
+            {
+                new SimConnectFacilityMinimal
+                {
+                    Icao = SimConnectIcao.FromStrings("SUB1"),
+                    LatLonAlt = default,
+                },
+            };
+
+            using (var enterMessage = FacilityMessageBuilder.CreateMinimalListMessage(entry.EnterRequestId, facilities))
+            {
+                manager.ProcessFacilityMinimalList(enterMessage.Pointer);
+            }
+
+            using (var exitMessage = FacilityMessageBuilder.CreateMinimalListMessage(entry.ExitRequestId, facilities))
+            {
+                manager.ProcessFacilityMinimalList(exitMessage.Pointer);
+            }
+
+            Assert.Equal(new[] { "SUB1" }, entered);
+            Assert.Equal(new[] { "SUB1" }, exited);
+        }
+
+        /// <summary>
+        /// Provides helper methods to create simulated facility messages.
+        /// </summary>
+        private static class FacilityMessageBuilder
+        {
+            /// <summary>
+            /// Creates a simulated facility minimal list message.
+            /// </summary>
+            /// <param name="requestId">The request identifier associated with the list.</param>
+            /// <param name="facilities">The facilities included in the message.</param>
+            /// <returns>A disposable message handle.</returns>
+            public static FacilityMessageHandle CreateMinimalListMessage(uint requestId, IReadOnlyList<SimConnectFacilityMinimal> facilities)
+            {
+                var header = new MinimalListHeader
+                {
+                    Size = (uint)(MinimalListHeader.SizeInBytes + (Marshal.SizeOf<SimConnectFacilityMinimal>() * facilities.Count)),
+                    Version = 1,
+                    Id = (uint)SimConnectRecvId.FacilityMinimalList,
+                    RequestId = requestId,
+                    ArraySize = (uint)facilities.Count,
+                    EntryNumber = 0,
+                    OutOf = 1,
+                };
+
+                var headerBytes = StructureToBytes(header);
+                var elementSize = Marshal.SizeOf<SimConnectFacilityMinimal>();
+                var totalSize = headerBytes.Length + (elementSize * facilities.Count);
+                var buffer = new byte[totalSize];
+                Array.Copy(headerBytes, buffer, headerBytes.Length);
+
+                if (facilities.Count > 0)
+                {
+                    var elementPtr = Marshal.AllocHGlobal(elementSize);
+                    try
+                    {
+                        for (int i = 0; i < facilities.Count; i++)
+                        {
+                            Marshal.StructureToPtr(facilities[i], elementPtr, false);
+                            Marshal.Copy(elementPtr, buffer, headerBytes.Length + (i * elementSize), elementSize);
+                        }
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal(elementPtr);
+                    }
+                }
+
+                return FacilityMessageHandle.Factory.FromBuffer(buffer);
+            }
+
+            /// <summary>
+            /// Creates a simulated facility data message for the specified payload.
+            /// </summary>
+            /// <param name="requestId">The request identifier.</param>
+            /// <param name="type">The facility data type.</param>
+            /// <param name="payload">The payload bytes to embed.</param>
+            /// <returns>A disposable message handle.</returns>
+            public static FacilityMessageHandle CreateFacilityDataMessage(uint requestId, SimConnectFacilityDataType type, byte[] payload)
+            {
+                var header = new FacilityDataHeader
+                {
+                    Size = (uint)(FacilityDataHeader.PayloadOffset + payload.Length),
+                    Version = 1,
+                    Id = (uint)SimConnectRecvId.FacilityData,
+                    UserRequestId = requestId,
+                    UniqueRequestId = 42,
+                    ParentUniqueRequestId = 0,
+                    Type = type,
+                    IsListItem = 0,
+                    ItemIndex = 0,
+                    ListSize = 0,
+                    Data = 0,
+                };
+
+                var headerBytes = StructureToBytes(header);
+                var totalSize = Math.Max(headerBytes.Length, FacilityDataHeader.PayloadOffset + payload.Length);
+                var buffer = new byte[totalSize];
+                Array.Copy(headerBytes, buffer, headerBytes.Length);
+                Array.Copy(payload, 0, buffer, FacilityDataHeader.PayloadOffset, payload.Length);
+
+                return FacilityMessageHandle.Factory.FromBuffer(buffer, FacilityDataHeader.PayloadOffset + payload.Length);
+            }
+
+            /// <summary>
+            /// Converts a structure into a byte array for native marshalling tests.
+            /// </summary>
+            /// <typeparam name="T">The structure type.</typeparam>
+            /// <param name="value">The value to copy.</param>
+            /// <returns>A byte array containing the structure.</returns>
+            private static byte[] StructureToBytes<T>(T value)
+                where T : struct
+            {
+                var size = Marshal.SizeOf<T>();
+                var ptr = Marshal.AllocHGlobal(size);
+                try
+                {
+                    Marshal.StructureToPtr(value, ptr, false);
+                    var buffer = new byte[size];
+                    Marshal.Copy(ptr, buffer, 0, size);
+                    return buffer;
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private struct MinimalListHeader
+            {
+                public static readonly int SizeInBytes = Marshal.SizeOf<MinimalListHeader>();
+
+                public uint Size;
+                public uint Version;
+                public uint Id;
+                public uint RequestId;
+                public uint ArraySize;
+                public uint EntryNumber;
+                public uint OutOf;
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private struct FacilityDataHeader
+            {
+                public static readonly int PayloadOffset = Marshal.SizeOf<FacilityDataHeader>() - sizeof(uint);
+
+                public uint Size;
+                public uint Version;
+                public uint Id;
+                public uint UserRequestId;
+                public uint UniqueRequestId;
+                public uint ParentUniqueRequestId;
+                public SimConnectFacilityDataType Type;
+                public uint IsListItem;
+                public uint ItemIndex;
+                public uint ListSize;
+                public uint Data;
+            }
+        }
+
+        /// <summary>
+        /// Disposable wrapper around unmanaged facility message buffers.
+        /// </summary>
+        private sealed class FacilityMessageHandle : IDisposable
+        {
+            private FacilityMessageHandle(IntPtr pointer, int length)
+            {
+                this.Pointer = pointer;
+                this.Length = length;
+            }
+
+            /// <summary>
+            /// Gets the unmanaged pointer to the simulated message.
+            /// </summary>
+            public IntPtr Pointer { get; }
+
+            /// <summary>
+            /// Gets the length of the unmanaged buffer.
+            /// </summary>
+            public int Length { get; }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+                if (this.Pointer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(this.Pointer);
+                }
+            }
+
+            /// <summary>
+            /// Factory helpers for creating <see cref="FacilityMessageHandle"/> instances.
+            /// </summary>
+            public static class Factory
+            {
+                /// <summary>
+                /// Creates a disposable facility message handle from the provided buffer.
+                /// </summary>
+                /// <param name="buffer">The buffer to copy into unmanaged memory.</param>
+                /// <param name="sizeOverride">Optional size override when the buffer is larger than the payload.</param>
+                /// <returns>A disposable facility message handle.</returns>
+                public static FacilityMessageHandle FromBuffer(byte[] buffer, int? sizeOverride = null)
+                {
+                    var size = sizeOverride ?? buffer.Length;
+                    var ptr = Marshal.AllocHGlobal(size);
+                    Marshal.Copy(buffer, 0, ptr, size);
+                    return new FacilityMessageHandle(ptr, size);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fake facility API used to capture facility requests.
+        /// </summary>
+        private sealed class FakeFacilityApi : ISimConnectFacilityApi
+        {
+            public List<(uint DefinitionId, string Field)> AddedFields { get; } = new();
+
+            public List<(uint Type, uint RequestId)> MinimalRequests { get; } = new();
+
+            public List<(uint DefinitionId, uint RequestId, string Icao, string Region)> DataRequests { get; } = new();
+
+            public List<(uint Type, uint EnterRequestId, uint ExitRequestId)> Subscriptions { get; } = new();
+
+            public List<(uint Type, bool NewRange, bool OldRange)> Unsubscriptions { get; } = new();
+
+            public int AddToFacilityDefinition(IntPtr handle, uint definitionId, string fieldName)
+            {
+                this.AddedFields.Add((definitionId, fieldName));
+                return 0;
+            }
+
+            public int RequestFacilityData(IntPtr handle, uint definitionId, uint requestId, string icao, string region)
+            {
+                this.DataRequests.Add((definitionId, requestId, icao, region));
+                return 0;
+            }
+
+            public int RequestFacilitiesList(IntPtr handle, uint type, uint requestId)
+            {
+                return 0;
+            }
+
+            public int RequestFacilitiesListEx1(IntPtr handle, uint type, uint requestId)
+            {
+                this.MinimalRequests.Add((type, requestId));
+                return 0;
+            }
+
+            public int SubscribeToFacilitiesEx1(IntPtr handle, uint type, uint newInRangeRequestId, uint oldOutRangeRequestId)
+            {
+                this.Subscriptions.Add((type, newInRangeRequestId, oldOutRangeRequestId));
+                return 0;
+            }
+
+            public int UnsubscribeFromFacilitiesEx1(IntPtr handle, uint type, bool unsubscribeNewInRange, bool unsubscribeOldOutRange)
+            {
+                this.Unsubscriptions.Add((type, unsubscribeNewInRange, unsubscribeOldOutRange));
+                return 0;
+            }
+        }
+    }
+}

--- a/tests/SimConnect.NET.UnitTests/SimConnect.NET.UnitTests.csproj
+++ b/tests/SimConnect.NET.UnitTests/SimConnect.NET.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SimConnect.NET\SimConnect.NET.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a fully-managed facility manager with builders, annotations, and subscription helpers tied into the core client
- expose facility definitions/results/subscriptions plus the facility SimConnect API wrapper and ICAO marshaling helpers
- add an xUnit test project that exercises definition creation, minimal list requests, facility data collection, and subscription dispatching

## Testing
- `dotnet test tests/SimConnect.NET.UnitTests/SimConnect.NET.UnitTests.csproj -p:TargetFrameworks=net8.0 -p:TargetFramework=net8.0`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197255f8888328af277976ae85db07)